### PR TITLE
Adding delayed action execution option

### DIFF
--- a/classes/ScheduledAction.php
+++ b/classes/ScheduledAction.php
@@ -1,0 +1,63 @@
+<?php namespace RainLab\Notify\Classes;
+
+use Rainlab\Notify\Models\RuleAction;
+
+class ScheduledAction
+{
+    use \Illuminate\Queue\InteractsWithQueue;
+    use \Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
+
+    protected $action;
+    protected $params;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param  array  $params
+     * @return void
+     */
+    public function __construct($action, array $params)
+    {
+        $this->action = $action->id;
+        $this->params = $this->serializeParams($params);
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->delete();
+
+        if (! $actionClass = RuleAction::find($this->action)) {
+            return traceLog('Error: Could not restore action #' . $this->action);
+        }
+
+        $params = $this->unserializeParams();
+        $actionClass->triggerAction($params, false);
+    }
+
+    protected function serializeParams($params)
+    {
+        $result = [];
+
+        foreach ($params as $param => $value) {
+            $result[$param] = $this->getSerializedPropertyValue($value);
+        }
+
+        return $result;
+    }
+
+    protected function unserializeParams()
+    {
+        $result = [];
+
+        foreach ($this->params as $param => $value) {
+            $result[$param] = $this->getRestoredPropertyValue($value);
+        }
+
+        return $result;
+    }
+}

--- a/formwidgets/ActionBuilder.php
+++ b/formwidgets/ActionBuilder.php
@@ -159,7 +159,7 @@ class ActionBuilder extends FormWidgetBase
 
             $data = $this->getCacheActionAttributes($action);
 
-            if (! is_null($this->actionFormWidget)) {
+            if (!is_null($this->actionFormWidget)) {
                 $this->actionFormWidget->setFormValues($data);
             }
             $this->actionScheduleFormWidget->setFormValues($data);

--- a/formwidgets/actionbuilder/assets/js/actions.js
+++ b/formwidgets/actionbuilder/assets/js/actions.js
@@ -60,15 +60,17 @@ function showActionSettings(id) {
     RuleActions.prototype.onShowNewActionSettings = function(actionId) {
         var $el = $('[data-action-id='+actionId+']')
 
+        var popup_size = 'giant';
         // Action does not use settings
         if ($el.hasClass('no-form')) {
-            return
+            // Popup will contain scheduling option only
+            popup_size = 'medium'
         }
 
         $el.popup({
             handler: this.options.settingsHandler,
             extraData: { current_action_id: actionId },
-            size: 'giant'
+            size: popup_size
         })
 
         // This will not fire on successful save because the target element
@@ -91,15 +93,16 @@ function showActionSettings(id) {
         var $el = $(event.target),
             actionId = getActionIdFromElement($el)
 
+        var popup_size = 'giant';
         // Action does not use settings
         if ($el.closest('li.action-item').hasClass('no-form')) {
-            return
+            popup_size = 'medium'
         }
 
         $el.popup({
             handler: this.options.settingsHandler,
             extraData: { current_action_id: actionId },
-            size: 'giant'
+            size: popup_size
         })
 
         return false

--- a/formwidgets/actionbuilder/partials/_action_settings_form.htm
+++ b/formwidgets/actionbuilder/partials/_action_settings_form.htm
@@ -17,7 +17,7 @@
         <input type="hidden" name="current_action_data" value="<?= e(json_encode($this->getCacheActionDataPayload())) ?>" />
 
         <div class="modal-body">
-            <?php if($actionFormWidget): ?>
+            <?php if ($actionFormWidget): ?>
                 <div class="row">
                     <div class="col-md-8">
                         <?= $actionFormWidget->render() ?>

--- a/formwidgets/actionbuilder/partials/_action_settings_form.htm
+++ b/formwidgets/actionbuilder/partials/_action_settings_form.htm
@@ -17,14 +17,20 @@
         <input type="hidden" name="current_action_data" value="<?= e(json_encode($this->getCacheActionDataPayload())) ?>" />
 
         <div class="modal-body">
-            <div class="row">
-                <div class="col-md-8">
-                    <?= $actionFormWidget->render() ?>
+            <?php if($actionFormWidget): ?>
+                <div class="row">
+                    <div class="col-md-8">
+                        <?= $actionFormWidget->render() ?>
+                    </div>
+                    <div class="col-md-4">
+                        <?= $this->makePartial('available_tags') ?>
+
+                        <?= $this->makePartial('schedule') ?>
+                    </div>
                 </div>
-                <div class="col-md-4">
-                    <?= $this->makePartial('available_tags') ?>
-                </div>
-            </div>
+            <?php else: ?>
+                <?= $this->makePartial('schedule') ?>
+            <?php endif ?>
         </div>
         <div class="modal-footer">
             <button

--- a/formwidgets/actionbuilder/partials/_schedule.htm
+++ b/formwidgets/actionbuilder/partials/_schedule.htm
@@ -1,0 +1,22 @@
+<div class="form-preview">
+    <p>
+        <i class="icon-clock-o"></i>
+        <?= e(trans('rainlab.notify::lang.action.schedule')) ?>
+    </p>
+    <p>
+        <?= $actionScheduleFormWidget->render() ?>
+    </p>
+    <div class="small">
+        <em>
+            <?php if(in_array($queueDriver, ['sync', 'sqs'])): ?>
+                <i class="icon-warning"></i>
+                <?= e(trans('rainlab.notify::lang.action.schedule_unsupported')) ?>
+            <?php else: ?>
+                <?= e(trans('rainlab.notify::lang.action.schedule_notice')) ?>
+            <?php endif ?>
+        </em>
+        <a target="_blank" href="https://octobercms.com/docs/services/queues#basic-usage">
+            <?= e(trans('rainlab.notify::lang.action.schedule_notice_more')) ?>
+        </a>
+    </div>
+</div>

--- a/formwidgets/actionbuilder/partials/_schedule.htm
+++ b/formwidgets/actionbuilder/partials/_schedule.htm
@@ -8,7 +8,7 @@
     </p>
     <div class="small">
         <em>
-            <?php if(in_array($queueDriver, ['sync', 'sqs'])): ?>
+            <?php if (in_array($queueDriver, ['sync', 'sqs'])): ?>
                 <i class="icon-warning"></i>
                 <?= e(trans('rainlab.notify::lang.action.schedule_unsupported')) ?>
             <?php else: ?>

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -11,5 +11,9 @@ return [
     ],
     'action' => [
         'add_notification_action' => 'Add notification action',
+        'schedule' => 'Schedule',
+        'schedule_notice' => 'Note that scheduling might not work for certain queue driver configurations.',
+        'schedule_notice_more' => 'Learn more',
+        'schedule_unsupported' => 'The configured queue driver does not support delayed execution.'
     ],
 ];

--- a/models/RuleAction.php
+++ b/models/RuleAction.php
@@ -48,8 +48,10 @@ class RuleAction extends Model
     public function triggerAction($params, $scheduled=true)
     {
         try {
+            $actionObject = $this->getActionObject();
+
             // Check if action is muted in which case we don't proceed sending a notification
-            if (method_exists($this, 'isMuted') && ! $this->isMuted()) {
+            if (method_exists($actionObject, 'isMuted') && $actionObject->isMuted()) {
                 return;
             }
 
@@ -62,7 +64,7 @@ class RuleAction extends Model
             }
             else {
                 // We trigger the action
-                $this->getActionObject()->triggerAction($params);
+                $actionObject->triggerAction($params);
             }
         }
         catch (Exception $ex) {

--- a/models/RuleAction.php
+++ b/models/RuleAction.php
@@ -162,7 +162,8 @@ class RuleAction extends Model
         }
     }
 
-    public function getSchedule() {
+    public function getSchedule()
+    {
         if ($this->schedule_type != 'delayed') {
             return false;
         }

--- a/models/RuleAction.php
+++ b/models/RuleAction.php
@@ -164,7 +164,7 @@ class RuleAction extends Model
 
     public function getSchedule()
     {
-        if ($this->schedule_type != 'delayed') {
+        if ($this->schedule_type !== 'delayed') {
             return false;
         }
 

--- a/models/RuleAction.php
+++ b/models/RuleAction.php
@@ -45,7 +45,7 @@ class RuleAction extends Model
         'notification_rule' => [NotificationRule::class, 'key' => 'rule_host_id'],
     ];
 
-    public function triggerAction($params, $scheduled=true)
+    public function triggerAction($params, $scheduled = true)
     {
         try {
             $actionObject = $this->getActionObject();

--- a/models/RuleAction.php
+++ b/models/RuleAction.php
@@ -126,7 +126,9 @@ class RuleAction extends Model
 
         $metaAttributes = [
             'action_text',
-            'schedule_type', 'schedule_delay', 'schedule_delay_factor'
+            'schedule_type',
+            'schedule_delay',
+            'schedule_delay_factor',
         ];
 
         $formAttributes = [];

--- a/models/ruleaction/fields_schedule.yaml
+++ b/models/ruleaction/fields_schedule.yaml
@@ -1,0 +1,30 @@
+# ===================================
+#  Form Field Definitions
+# ===================================
+
+fields:
+    schedule_type:
+        type: dropdown
+        options:
+            disabled: None
+            delayed: Delay execution
+    schedule_delay:
+        type: number
+        span: left
+        trigger:
+            action: show
+            field: schedule_type
+            condition: value[delayed]
+    schedule_delay_factor:
+        type: dropdown
+        span: right
+        options:
+            1: Seconds
+            60: Minutes
+            3600: Hours
+            86400: Days
+            2592000: Months
+        trigger:
+            action: show
+            field: schedule_type
+            condition: value[delayed]


### PR DESCRIPTION
Implements #6 using Queues. Action settings page is being extended with the option to define an action execution delay. The delay schedule configuration is stored in the `config_data` field of the actions table (I'm not sure if that's the best solution because it might collide with the config form fields, feedback welcome).