### PR TITLE
Add "registerPermissions"

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -48,4 +48,14 @@ class Plugin extends PluginBase
             ],
         ];
     }
+
+    public function registerPermissions()
+    {
+        return [
+            'rainlab.notify.manage_notifications' => [
+                'tab' => SettingsManager::CATEGORY_NOTIFICATIONS,
+                'label' => 'Notifications management'
+            ],
+        ];
+    }
 }

--- a/Plugin.php
+++ b/Plugin.php
@@ -54,7 +54,7 @@ class Plugin extends PluginBase
         return [
             'rainlab.notify.manage_notifications' => [
                 'tab' => SettingsManager::CATEGORY_NOTIFICATIONS,
-                'label' => 'Notifications management'
+                'label' => 'rainlab.notify::lang.permissions.manage_notifications'
             ],
         ];
     }

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -12,4 +12,7 @@ return [
     'action' => [
         'add_notification_action' => 'Add notification action',
     ],
+    'permissions' => [
+        'manage_notifications' => 'Notifications management',
+    ],
 ];


### PR DESCRIPTION
Plugin uses 'rainlab.notify.manage_notifications' in controller 'Notifications', but it permission is not registered.