### PR TITLE
Use Laravel's Request object to change request -POST- values

### DIFF
--- a/formwidgets/ActionBuilder.php
+++ b/formwidgets/ActionBuilder.php
@@ -6,6 +6,7 @@ use RainLab\Notify\Classes\ActionBase;
 use ApplicationException;
 use ValidationException;
 use Exception;
+use Request;
 
 /**
  * Action builder
@@ -245,12 +246,16 @@ class ActionBuilder extends FormWidgetBase
 
         $cache[$action->id] = json_encode($this->makeCacheActionData($action));
 
-        $_POST['action_data'] = $cache;
+        $requestData = Request::all();
+        array_set($requestData, 'action_data' , $cache);
+        Request::merge($requestData);         
     }
 
     public function restoreCacheActionDataPayload()
     {
-        $_POST['action_data'] = json_decode(post('current_action_data'), true);
+        $requestData = Request::all();
+        array_set($requestData, 'action_data' , json_decode(post('current_action_data'), true));
+        Request::merge($requestData);          
     }
 
     public function getCacheActionDataPayload()

--- a/formwidgets/ConditionBuilder.php
+++ b/formwidgets/ConditionBuilder.php
@@ -6,6 +6,7 @@ use RainLab\Notify\Classes\ConditionBase;
 use ApplicationException;
 use ValidationException;
 use Exception;
+use Request;
 
 /**
  * Condition builder
@@ -348,12 +349,16 @@ class ConditionBuilder extends FormWidgetBase
 
         $cache[$condition->id] = json_encode($this->makeCacheConditionData($condition));
 
-        $_POST['condition_data'] = $cache;
+        $requestData = Request::all();
+        array_set($requestData, 'condition_data' , $cache);
+        Request::merge($requestData);         
     }
 
     public function restoreCacheConditionDataPayload()
     {
-        $_POST['condition_data'] = json_decode(post('current_condition_data'), true);
+        $requestData = Request::all();
+        array_set($requestData, 'condition_data' , json_decode(post('current_condition_data'), true));
+        Request::merge($requestData);     
     }
 
     public function getCacheConditionDataPayload()

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -5,3 +5,4 @@
     - create_rule_conditions_table.php
     - create_rule_actions_table.php
 1.0.2: Fixes crashing bug.
+1.0.3: Fixes POST variable access bug.


### PR DESCRIPTION
The helper methods in octobercms/library used to rely on global $_POST variables, but since version 1.0.450 they pull request values from the app container using Laravel's Request object. This fix the value field from CondtitionBuilder formwidget not being saved because the changes were applied to the global $_POST variable.